### PR TITLE
Add udp

### DIFF
--- a/src/final/hotflow.ini
+++ b/src/final/hotflow.ini
@@ -1,6 +1,6 @@
 [Server]
 Port=1234
-Protocol=TCP
+Protocol=UDP
 
 [Control]
 # remember to change gitvc and ignition to false for coldflow

--- a/src/final/main_network_worker.cpp
+++ b/src/final/main_network_worker.cpp
@@ -30,14 +30,14 @@ bool main_network_worker::process_nqi(network_queue_item &nqi) {
         }
         case (nq_send): {
             circular_buffer *buff = nqi.buff;
+            send_header_t header;
 
-            send_code h = (send_code) nqi.data[0];
+            header.code = (send_code) nqi.data[0];
+            header.nbytes = nqi.nbytes;
 
             // TODO this header should correspond to something from the nqi data.
 
             // TODO error check
-            network_worker::send_header(h, nqi.nbytes);
-
 //            std::cerr << "Preparing header" << std::endl;
 //
 //            send_header_t sh = (send_header_t) {h, nqi.nbytes};
@@ -54,9 +54,6 @@ bool main_network_worker::process_nqi(network_queue_item &nqi) {
 //                std::cerr << "Copy bytes from buffer failed!" << std::endl;
 //            }
 
-            logger.debug("Writing data: Nbytes: " + std::to_string(nqi.nbytes) + " Type: " + std::to_string(h));
-            int connfd = (connfd_udp != -1) ? connfd_udp : connfd_tcp; //Use UDP if the socket is configured
-
 //            ssize_t bytes_written = 0;
 //            if ((bytes_written = write(connfd, combined_buff, nqi.nbytes)) != nqi.nbytes) {
 //                std:: cerr << "Incorrect number of bytes written: " << "Expected " << nqi.nbytes << ", Actual " << bytes_written << std::endl;
@@ -65,7 +62,7 @@ bool main_network_worker::process_nqi(network_queue_item &nqi) {
 //            sendto(connfd, "abc", 4, 0, &sa_udp, sizeof(struct sockaddr_in));
 //            std::cout << "Sent on UDP" << std::endl;
 
-            if (buff->write_data(connfd, nqi.nbytes, nqi.total_bytes) != 0) {
+            if (buff->write_data_datagram(connfd_udp, nqi.nbytes, nqi.total_bytes, &header, sizeof(send_header_t), &sa_udp) != 0) {
                 std::cerr << "Connection Closed" << std::endl;
                 //exit(0);
             }

--- a/src/final/main_network_worker.cpp
+++ b/src/final/main_network_worker.cpp
@@ -15,54 +15,27 @@
 
 
 bool main_network_worker::process_nqi(network_queue_item &nqi) {
-    char c;
-    work_queue_item wqi;
-    ssize_t read_result;
     // char* combined_buff = new char[1 << 12];
 
     Logger logger("logs/nw.log", "network thread", LOG_INFO);
 
     switch (nqi.action) {
         case (nq_recv): {
-//            //Poll before we read:
-//            read_result = do_recv(connfd_tcp, &c, 1);
-//            if (read_result <= 0) {
-//                //FIXME, do something better?
-//                return true;
-//            }
-//            //TODO just make this a process and let the logic in the worker handle it.
-//            /*
-//             * If we get a '0' then start processing stuff.
-//             * If we get a '1' then stop processing stuff.
-//             * Otherwise ignore the message.
-//             */
-//            logger.info("Received command " + std::to_string((uint8_t) c));
-//            wqi.action = wq_process;
-//            wqi.data[0] = c;
-//            qw.enqueue(wqi);
             std::cerr << "Processing a recv\n";
             return true;
         }
         case (nq_send_ack): {
             // Don't actually send an ack. Just don't timeout for now.
-            //network_worker::send_header(ack, 0);
             break;
         }
         case (nq_send): {
-            //Poll before we read:
-//            if (poll(&pf, 1, 0) == 0) {
-//                if (!pf.revents & POLLOUT) {
-//                    //Cannot write. Will block.
-//                    logger.error("Socket blocked on write.");
-//                    return true;
-//                }
-//            }
             circular_buffer *buff = nqi.buff;
 
             send_code h = (send_code) nqi.data[0];
 
             // TODO this header should correspond to something from the nqi data.
 
+            // TODO error check
             network_worker::send_header(h, nqi.nbytes);
 
 //            std::cerr << "Preparing header" << std::endl;
@@ -89,13 +62,13 @@ bool main_network_worker::process_nqi(network_queue_item &nqi) {
 //                std:: cerr << "Incorrect number of bytes written: " << "Expected " << nqi.nbytes << ", Actual " << bytes_written << std::endl;
 //            }
 
-            sendto(connfd, "abc", 4, 0, &sa_udp, sizeof(struct sockaddr_in));
-            std::cout << "Sent on UDP" << std::endl;
+//            sendto(connfd, "abc", 4, 0, &sa_udp, sizeof(struct sockaddr_in));
+//            std::cout << "Sent on UDP" << std::endl;
 
-//            if (buff->write_data(connfd, nqi.nbytes, nqi.total_bytes) != 0) {
-//                std::cerr << "Connection Closed" << std::endl;
-//                //exit(0);
-//            }
+            if (buff->write_data(connfd, nqi.nbytes, nqi.total_bytes) != 0) {
+                std::cerr << "Connection Closed" << std::endl;
+                //exit(0);
+            }
 
             return true;
         }

--- a/src/final/main_network_worker.cpp
+++ b/src/final/main_network_worker.cpp
@@ -8,6 +8,11 @@
 #include <unistd.h>
 #include "main_network_worker.hpp"
 #include "../util/logger.hpp"
+#include <arpa/inet.h>
+#include<netinet/in.h>
+#include<sys/socket.h>
+#include<sys/types.h>
+
 
 bool main_network_worker::process_nqi(network_queue_item &nqi) {
     char c;
@@ -19,22 +24,23 @@ bool main_network_worker::process_nqi(network_queue_item &nqi) {
 
     switch (nqi.action) {
         case (nq_recv): {
-            //Poll before we read:
-            read_result = do_recv(connfd_tcp, &c, 1);
-            if (read_result <= 0) {
-                //FIXME, do something better?
-                return true;
-            }
-            //TODO just make this a process and let the logic in the worker handle it.
-            /*
-             * If we get a '0' then start processing stuff.
-             * If we get a '1' then stop processing stuff.
-             * Otherwise ignore the message.
-             */
-            logger.info("Received command " + std::to_string((uint8_t) c));
-            wqi.action = wq_process;
-            wqi.data[0] = c;
-            qw.enqueue(wqi);
+//            //Poll before we read:
+//            read_result = do_recv(connfd_tcp, &c, 1);
+//            if (read_result <= 0) {
+//                //FIXME, do something better?
+//                return true;
+//            }
+//            //TODO just make this a process and let the logic in the worker handle it.
+//            /*
+//             * If we get a '0' then start processing stuff.
+//             * If we get a '1' then stop processing stuff.
+//             * Otherwise ignore the message.
+//             */
+//            logger.info("Received command " + std::to_string((uint8_t) c));
+//            wqi.action = wq_process;
+//            wqi.data[0] = c;
+//            qw.enqueue(wqi);
+            std::cerr << "Processing a recv\n";
             return true;
         }
         case (nq_send_ack): {
@@ -44,13 +50,13 @@ bool main_network_worker::process_nqi(network_queue_item &nqi) {
         }
         case (nq_send): {
             //Poll before we read:
-            if (poll(&pf, 1, 0) == 0) {
-                if (!pf.revents & POLLOUT) {
-                    //Cannot write. Will block.
-                    logger.error("Socket blocked on write.");
-                    return true;
-                }
-            }
+//            if (poll(&pf, 1, 0) == 0) {
+//                if (!pf.revents & POLLOUT) {
+//                    //Cannot write. Will block.
+//                    logger.error("Socket blocked on write.");
+//                    return true;
+//                }
+//            }
             circular_buffer *buff = nqi.buff;
 
             send_code h = (send_code) nqi.data[0];
@@ -83,10 +89,13 @@ bool main_network_worker::process_nqi(network_queue_item &nqi) {
 //                std:: cerr << "Incorrect number of bytes written: " << "Expected " << nqi.nbytes << ", Actual " << bytes_written << std::endl;
 //            }
 
-            if (buff->write_data(connfd, nqi.nbytes, nqi.total_bytes) != 0) {
-                std::cerr << "Connection Closed" << std::endl;
-                //exit(0);
-            }
+            sendto(connfd, "abc", 4, 0, &sa_udp, sizeof(struct sockaddr_in));
+            std::cout << "Sent on UDP" << std::endl;
+
+//            if (buff->write_data(connfd, nqi.nbytes, nqi.total_bytes) != 0) {
+//                std::cerr << "Connection Closed" << std::endl;
+//                //exit(0);
+//            }
 
             return true;
         }

--- a/src/final/main_network_worker.cpp
+++ b/src/final/main_network_worker.cpp
@@ -92,6 +92,7 @@ bool main_network_worker::process_nqi(network_queue_item &nqi) {
         }
 
         default: {
+            // TODO should this ever happen?
             return network_worker::process_nqi(nqi);
         }
     }

--- a/src/server/network_worker.hpp
+++ b/src/server/network_worker.hpp
@@ -76,11 +76,7 @@ class network_worker : public worker {
          */
         void open_connection();
 
-        send_header_t* prepare_header(send_code h, size_t nbytes);
-
         ssize_t send_header(send_code h, size_t nbytes);
-
-        ssize_t rwrite(int fd, void *b, size_t n);
 
     protected:
         /**

--- a/src/server/network_worker.hpp
+++ b/src/server/network_worker.hpp
@@ -84,7 +84,7 @@ class network_worker : public worker {
          */
         void open_connection();
 
-        ssize_t send_header(send_code h, size_t nbytes);
+        bool send_header(send_code h, size_t nbytes);
 
     protected:
         /**

--- a/src/server/network_worker.hpp
+++ b/src/server/network_worker.hpp
@@ -16,6 +16,10 @@
 #include <poll.h>
 #include "../util/circular_buffer.hpp"
 #include "../util/timestamps.hpp"
+#include <arpa/inet.h>
+#include<netinet/in.h>
+#include<sys/socket.h>
+#include<sys/types.h>
 
 class network_worker : public worker {
     public:
@@ -23,6 +27,7 @@ class network_worker : public worker {
         int connfd_tcp;
         int connfd_udp;
         bool connected;
+        struct sockaddr sa_udp, sa_tcp;
 
         /**
          * The number of microseconds where no receive has occured before the worker should treat the peer
@@ -44,11 +49,14 @@ class network_worker : public worker {
                 (safe_queue<network_queue_item> &my_qn, safe_queue<work_queue_item> &my_qw, int port,
                  timestamp_t timeout)
                 : worker(my_qn, my_qw)
+                , connected(0)
                 , port(port)
                 , last_recv(0)
                 , timeout(timeout)
                 , connfd_tcp(-1)
                 , connfd_udp(-1)
+                , sa_udp({})
+                , sa_tcp({})
         {
                 last_recv = get_time() - timeout; // Set the last time such that we are immediately timed out.
         };
@@ -87,9 +95,6 @@ class network_worker : public worker {
          * @return Whatever read returned. -2 if poll succeeded but there was nothing to receive. -3 if poll failed.
          */
         ssize_t do_recv(int fd, char *b, size_t nbytes);
-        pollfd pf;
-
-        bool has_acked;
 };
 
 

--- a/src/util/circular_buffer.cpp
+++ b/src/util/circular_buffer.cpp
@@ -5,7 +5,12 @@
 #include "unistd.h"
 #include <cstring>
 #include <iostream>
+#include <sys/socket.h>
 #include "circular_buffer.hpp"
+#include <arpa/inet.h>
+#include<netinet/in.h>
+#include<sys/socket.h>
+#include<sys/types.h>
 
 //#define DEBUG_CIRC_SEND
 
@@ -95,6 +100,8 @@ ssize_t circular_buffer::write_data(int fd, size_t n, size_t offset) {
 #endif
     ssize_t result;
     result = write(fd, data + offset % this->nbytes, to_send);
+    // result = sendto(fd, data + offset % this->nbytes, to_send, 0, destination, sizeof(struct sockaddr_in));
+
     if (result <= 0) {
         perror("help?");
         std::cerr << "Error while writing." << std::endl;

--- a/src/util/circular_buffer.cpp
+++ b/src/util/circular_buffer.cpp
@@ -115,6 +115,67 @@ ssize_t circular_buffer::write_data(int fd, size_t n, size_t offset) {
     }
 }
 
+ssize_t circular_buffer::write_data_datagram(int fd, size_t n, size_t offset, void *header, size_t header_size, sockaddr *destination) {
+    size_t bw = bytes_written.load();
+    char *send_buff = new char[header_size + n];
+    char *pos = send_buff;
+
+    /*
+    offset is smallest number we're trying to write.
+    bw - nbytes is the smallest number that hasn't been overwritten.
+    We want to ensure that we aren't trying to write data that has been overwritten.
+     */
+    if ((long) offset <  (long) (bw - this->nbytes)) {
+        std::cerr << "Bytes already overwritten before sending: Num_to_write:" << n
+                  << " Offset:" << offset
+                  << " Total bytes written into buffer" << bw
+                  << " Total buffer size: " << nbytes << std::endl;
+        //return -1; //TODO don't collide with write error?
+    }
+
+    // Copy in the header at the beginning
+    memcpy(pos, header, header_size);
+    pos += header_size;
+
+    size_t to_send = nbytes - offset % this->nbytes; // The distance between start and the end of the buffer.
+    to_send = to_send > n ? n : to_send; //Take the minimum value of n and to_send.
+
+    // Copy in the data
+    memcpy(pos, data + offset % this->nbytes, to_send);
+    pos += offset % this->nbytes;
+
+    if (n > to_send) {
+        memcpy(pos, data + (offset + to_send) % this->nbytes, n - to_send);
+    }
+
+#ifdef DEBUG_CIRC_SEND
+    if (to_send > 4 * 16) {
+        size_t temp_offset = offset % this->nbytes;
+
+        fprintf(stdout, "Offset %#u \n", (uint16_t) temp_offset);
+        fprintf(stdout, "Sending Bytes: %X %lld %X %lld %X %lld %X %lld \n",
+            *((uint16_t *)(data + temp_offset)), *((uint64_t *)(data + temp_offset + 8)),
+            *((uint16_t *)(data + temp_offset + 16)), *((uint64_t *)(data + temp_offset + 24)),
+            *((uint16_t *)(data + temp_offset + 32)), *((uint64_t *)(data + temp_offset + 40)),
+            *((uint16_t *)(data + temp_offset + 48)), *((uint64_t *)(data + temp_offset + 56)));
+    }
+#endif
+    ssize_t result;
+    // result = write(fd, data + offset % this->nbytes, to_send);
+    result = sendto(fd, send_buff, to_send, 0, destination, sizeof(struct sockaddr_in));
+
+    if (result <= 0) {
+        perror("help?");
+        std::cerr << "Error while writing." << std::endl;
+        return result;
+    } else if (result != n) {
+        std::cerr << "Error while writing. Wrote " << result << " bytes, expecting " << n << " bytes total\n";
+        return -1;
+    }
+
+    return 0;
+}
+
 void circular_buffer::zero() {
     bzero(data, nbytes);
     bytes_written = 0;

--- a/src/util/circular_buffer.cpp
+++ b/src/util/circular_buffer.cpp
@@ -14,10 +14,12 @@
 
 //#define DEBUG_CIRC_SEND
 
-circular_buffer::circular_buffer(size_t size) : bytes_written(0) {
+circular_buffer::circular_buffer(size_t size)
+    : bytes_written(0)
+    {
     this->nbytes = size;
     this->data = new char[size];
-}
+    }
 
 circular_buffer::~circular_buffer() {
     delete [] this->data;

--- a/src/util/circular_buffer.hpp
+++ b/src/util/circular_buffer.hpp
@@ -54,6 +54,9 @@ class circular_buffer {
          */
         ssize_t write_data(int fd, size_t n, size_t offset);
 
+        // TODO void * should be send_header_t*. Not for now due to circular include.
+        ssize_t write_data_datagram(int fd, size_t n, size_t offset, void *header, size_t header_size, struct sockaddr *destination);
+
         void zero();
 };
 

--- a/src/util/listener.cpp
+++ b/src/util/listener.cpp
@@ -4,6 +4,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <iostream>
 #include "listener.hpp"
 
 /*
@@ -81,15 +82,15 @@ int wait_for_connection(int port, sockaddr *sa) {
         fprintf(stderr, "Received request on connfd on %d\n", connfd);
     #endif /*DEBUG_LISTENER*/
 
-    // close(listenfd);
+    close(listenfd);
     return connfd;
 }
 
 int
-create_send_fd(int port, sockaddr *sa) {
+create_send_fd(int port, sockaddr_in *sa) {
     int udp_server_fd;
-    socklen_t sockaddr_len = sizeof(sockaddr_in);
-    struct sockaddr_in udp_server = {};
+    // socklen_t sockaddr_len = sizeof(sockaddr_in);
+    // struct sockaddr_in udp_server = {};
 
     if((udp_server_fd = socket(AF_INET, SOCK_DGRAM, 0)) == -1)
     {
@@ -97,12 +98,14 @@ create_send_fd(int port, sockaddr *sa) {
         exit(-1);
     }
 
-    udp_server.sin_family = AF_INET;
-    udp_server.sin_port = htons((uint16_t) port);
-    udp_server.sin_addr.s_addr = INADDR_ANY;
-    bzero(udp_server.sin_zero, 8);
+    sa->sin_family = AF_INET;
+    sa->sin_port = htons((uint16_t) port);
+    sa->sin_addr.s_addr = htonl(INADDR_ANY);
+    bzero(sa->sin_zero, 8);
 
-//    if(bind(udp_server_fd, (struct sockaddr *)&udp_server, sockaddr_len) == -1)
+    std::cerr << sa->sin_addr.s_addr << std::endl;
+
+//    if(bind(udp_server_fd, (struct sockaddr *)&udp_server, sizeof(struct sockaddr_in)) == -1)
 //    {
 //        perror("bind");
 //        exit(-1);

--- a/src/util/listener.hpp
+++ b/src/util/listener.hpp
@@ -22,7 +22,7 @@
  *
  * Effects:
  *  Listens on the port specified and blocks until a connection is recieved
- *  and then returns the corresponding fildes for the connection.
+ *  and then returns the corresponding file descriptors for the connection.
  *  TODO not sure what is being done with "sa"
  */
 int wait_for_connection(int port, sockaddr *sa);
@@ -36,5 +36,8 @@ int wait_for_connection(int port, sockaddr *sa);
  *   socket or -1 on error.
  */
 int open_listen(int port);
+
+// TODO
+int create_send_fd(int port, sockaddr *sa);
 
 #endif //SOFTWARE_LISTENER_HPP

--- a/src/util/listener.hpp
+++ b/src/util/listener.hpp
@@ -38,6 +38,6 @@ int wait_for_connection(int port, sockaddr *sa);
 int open_listen(int port);
 
 // TODO
-int create_send_fd(int port, sockaddr *sa);
+int create_send_fd(int port, sockaddr_in *sa);
 
 #endif //SOFTWARE_LISTENER_HPP


### PR DESCRIPTION
Add UDP for sending. Tested with final_mocked and python code in add_udp branch of mk1-1-frontend. 

Changed files:

- listener to add creation/destruction of UDP socket
- network_worker and main_network_worker to use select instead of network_queue_items for send/recv. recv timing in particular should be improved.
- circular_buffer to send across UDP in one call to sendto(). Code assumes the size of the data packets does not extend past the end of the buffer more than once.

TODO:
Does nbytes include the size of the header? Size of payload data is currently 16 bytes (i.e. size of header) less than nbytes when received. Not sure if this is expected.
